### PR TITLE
Resolving keymap conflict with SmartScale and Move

### DIFF
--- a/scripts/startup/HEAVYPOLY_HOTKEYS.py
+++ b/scripts/startup/HEAVYPOLY_HOTKEYS.py
@@ -3,7 +3,7 @@ bl_info = {
     "description": "Hotkeys",
     "author": "Vaughan Ling",
     "version": (0, 1, 0),
-    "blender": (2, 90, 0),
+    "blender": (4, 0, 0),
     "location": "",
     "warning": "",
     "wiki_url": "",
@@ -251,11 +251,34 @@ def Keymap_Heavypoly():
 
     kmi = km.keymap_items.new('wm.delete_without_prompt', 'X', 'PRESS')
 
+#Function to disable keymap confict
+def disable_default_kmi(km=None, idname=None, retries=10):
+    wm = bpy.context.window_manager
 
+    if not (km and idname) or retries < 1:
+        return
 
+    # the default keyconfig
+    kc = wm.keyconfigs['Blender']
+    for kmi in kc.keymaps[km].keymap_items:
+        if kmi.idname == idname:
+            kmi.active = False
+            print("Disabled", kmi.name)
+            return
+
+    print("Retrying..")
+    # add some delay
+    bpy.app.timers.register(
+        lambda: disable_default_kmi(km, idname, retries - 1),
+        first_interval=0.1)
 
 def register():
     Keymap_Heavypoly()
+    #disabling Resize so there is only SmartScale being used on S
+    disable_default_kmi('Object Mode', 'transform.resize')
+    #disabling this one to remove a weird bug,not being able to release mouse after a move
+    disable_default_kmi('3D View', 'transform.translate')
+
 
 def unregister():
     Keymap_Heavypoly()


### PR DESCRIPTION
Somehow the Resize keymap from Blender 4.0 onward was being prioritized over the SmartScale shortcut (S)  
When doing extrude in 3.6, the scale was automatically applied for better comfort, it was not working in 4.0 because of this conflict.

A Move shortcut needed to be disabled too.